### PR TITLE
Added folder browser (Windows only) and applied two Go conventions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ In the latter case, `filename` will be the empty string and `err` will equal `di
 Asks the user for a filename to write data into. If the user selects a file which already exists,
 an additional dialog is spawned to confirm they want to overwrite the existing file.
 
+    directory, err := dialog.Directory().Title("Load images").Browse()
+
+Asks the user for a directory. The directory dialog is **only supported on Windows** for now.
+
 # platform details
 * OSX: uses Cocoa's NSAlert/NSSavePanel/SOpenPanel clasess
 * Win32: uses MessageBox/GetOpenFileName/GetSaveFileName (via package github.com/AllenDang/w32)

--- a/dlgs.go
+++ b/dlgs.go
@@ -114,3 +114,26 @@ not to overwrite the file. */
 func (b *FileBuilder) Save() (string, error) {
 	return b.save()
 }
+
+type DirectoryBuilder struct {
+	Dlg
+	StartDir string
+}
+
+/* Directory initialises a DirectoryBuilder using the default configuration. */
+func Directory() *DirectoryBuilder {
+	return &DirectoryBuilder{}
+}
+
+/* Browse spawns the directory selection dialog using the configured settings,
+asking the user to select a single folder. Returns Cancelled as the error
+if the user cancels or closes the dialog. */
+func (b *DirectoryBuilder) Browse() (string, error) {
+	return b.browse()
+}
+
+/* Title specifies the title to be used for the dialog. */
+func (b *DirectoryBuilder) Title(title string) *DirectoryBuilder {
+	b.Dlg.Title = title
+	return b
+}

--- a/dlgs_darwin.go
+++ b/dlgs_darwin.go
@@ -48,3 +48,7 @@ func (b *FileBuilder) run(save int) (string, error) {
 	}
 	return f, err
 }
+
+func (b *DirectoryBuilder) browse() (string, error) {
+	panic("not implemented")
+}

--- a/dlgs_linux.go
+++ b/dlgs_linux.go
@@ -80,3 +80,7 @@ func chooseFile(title string, action gtk.FileChooserAction, b *FileBuilder) (str
 	}
 	return "", Cancelled
 }
+
+func (b *DirectoryBuilder) browse() (string, error) {
+	panic("not implemented")
+}

--- a/dlgs_windows.go
+++ b/dlgs_windows.go
@@ -118,3 +118,24 @@ func openfile(flags uint32, b *FileBuilder) (d filedlg) {
 	}
 	return d
 }
+
+type dirdlg struct {
+	bi *w32.BROWSEINFO
+}
+
+func selectdir(b *DirectoryBuilder) (d dirdlg) {
+	d.bi = &w32.BROWSEINFO{}
+	if b.Dlg.Title != "" {
+		d.bi.Title, _ = syscall.UTF16PtrFromString(b.Dlg.Title)
+	}
+	return d
+}
+
+func (b *DirectoryBuilder) browse() (string, error) {
+	d := selectdir(b)
+	res := w32.SHBrowseForFolder(d.bi)
+	if res == 0 {
+		return "", Cancelled
+	}
+	return w32.SHGetPathFromIDList(res), nil
+}


### PR DESCRIPTION
I've implemented the browser dialog (Windows only). An example is provided with an explicit message that it is (for now?) only supported on Windows.

Secondly I've applied two Go conventions (errors starting with Err prefix and line comments instead of block comments).