### PR TITLE
update broken url

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Asks the user for a directory.
 # platform details
 * OSX: uses Cocoa's NSAlert/NSSavePanel/NSOpenPanel classes
 * Win32: uses MessageBox/GetOpenFileName/GetSaveFileName (via package github.com/AllenDang/w32)
-* Linux: uses Gtk's MessageDialog/FileChooserDialog (via package github.com/mattn/gtk)
+* Linux: uses Gtk's MessageDialog/FileChooserDialog (via package github.com/mattn/go-gtk)
 
 # build
 ```


### PR DESCRIPTION
The link to github.com/mattn/gtk is broken. The makes a fix to correct link.