### PR TITLE
feat: support predefined filenames

### DIFF
--- a/cocoa/dlg.h
+++ b/cocoa/dlg.h
@@ -21,6 +21,7 @@ typedef struct {
 	char* buf; /* buffer to store selected file */
 	int nbuf; /* number of bytes allocated at buf */
 	char* title; /* title for dialog box (can be nil) */
+	char* filename; /* default filename for dialog box (can be nil) */
 	void** exts; /* list of valid extensions (elements actual type is NSString*) */
 	int numext; /* number of items in exts */
 	int relaxext; /* allow other extensions? */

--- a/cocoa/dlg.m
+++ b/cocoa/dlg.m
@@ -92,6 +92,9 @@ DlgResult fileDlg(FileDlgParams* params) {
 	if(self->params->title != nil) {
 		[panel setTitle:[[NSString alloc] initWithUTF8String:self->params->title]];
 	}
+	if(self->params->filename != nil) {
+		[panel setNameFieldStringValue:[[NSString alloc] initWithUTF8String:self->params->filename]];
+	}
 	if(self->params->numext > 0) {
 		[panel setAllowedFileTypes:[NSArray arrayWithObjects:(NSString**)self->params->exts count:self->params->numext]];
 	}

--- a/cocoa/dlg_darwin.go
+++ b/cocoa/dlg_darwin.go
@@ -59,19 +59,19 @@ func ErrorDlg(msg, title string) {
 
 const BUFSIZE = C.PATH_MAX
 
-func FileDlg(save bool, title string, exts []string, relaxExt bool) (string, error) {
+func FileDlg(save bool, title string, filename string, exts []string, relaxExt bool) (string, error) {
 	mode := C.LOADDLG
 	if save {
 		mode = C.SAVEDLG
 	}
-	return fileDlg(mode, title, exts, relaxExt)
+	return fileDlg(mode, title, filename, exts, relaxExt)
 }
 
 func DirDlg(title string) (string, error) {
-	return fileDlg(C.DIRDLG, title, nil, false)
+	return fileDlg(C.DIRDLG, title, "", nil, false)
 }
 
-func fileDlg(mode int, title string, exts []string, relaxExt bool) (string, error) {
+func fileDlg(mode int, title string, filename string, exts []string, relaxExt bool) (string, error) {
 	p := C.FileDlgParams{
 		mode: C.int(mode),
 		nbuf: BUFSIZE,
@@ -82,6 +82,10 @@ func fileDlg(mode int, title string, exts []string, relaxExt bool) (string, erro
 	if title != "" {
 		p.title = C.CString(title)
 		defer C.free(unsafe.Pointer(p.title))
+	}
+	if filename != "" {
+		p.filename = C.CString(filename)
+		defer C.free(unsafe.Pointer(p.filename))
 	}
 	if len(exts) > 0 {
 		if len(exts) > 999 {

--- a/dlgs.go
+++ b/dlgs.go
@@ -70,8 +70,9 @@ type FileFilter struct {
 // FileBuilder is used for creating file browsing dialogs.
 type FileBuilder struct {
 	Dlg
-	StartDir string
-	Filters  []FileFilter
+	StartDir  string
+	StartFile string
+	Filters   []FileFilter
 }
 
 // File initialises a FileBuilder using the default configuration.
@@ -102,6 +103,12 @@ func (b *FileBuilder) Filter(desc string, extensions ...string) *FileBuilder {
 // SetStartDir specifies the initial directory of the dialog.
 func (b *FileBuilder) SetStartDir(startDir string) *FileBuilder {
 	b.StartDir = startDir
+	return b
+}
+
+// SetStartFile specifies the initial file name of the dialog.
+func (b *FileBuilder) SetStartFile(startFile string) *FileBuilder {
+	b.StartFile = startFile
 	return b
 }
 

--- a/dlgs_darwin.go
+++ b/dlgs_darwin.go
@@ -42,7 +42,7 @@ func (b *FileBuilder) run(save bool) (string, error) {
 		** dialog, so if "*" is a possible extension we must always show all files. */
 		exts = nil
 	}
-	f, err := cocoa.FileDlg(save, b.Dlg.Title, exts, star)
+	f, err := cocoa.FileDlg(save, b.Dlg.Title, b.StartFile, exts, star)
 	if f == "" && err == nil {
 		return "", ErrCancelled
 	}

--- a/dlgs_linux.go
+++ b/dlgs_linux.go
@@ -92,6 +92,11 @@ func chooseFile(title string, buttonText string, action C.GtkFileChooserAction, 
 		defer C.free(unsafe.Pointer(cdir))
 		C.gtk_file_chooser_set_current_folder(fdlg, cdir)
 	}
+	if b.StartFile != "" {
+		cfile := C.CString(b.StartFile)
+		defer C.free(unsafe.Pointer(cdir))
+		C.gtk_file_chooser_set_current_name(fdlg, cfile)
+	}
 	C.gtk_file_chooser_set_do_overwrite_confirmation(fdlg, C.TRUE)
 	r := C.gtk_dialog_run((*C.GtkDialog)(unsafe.Pointer(dlg)))
 	defer closeDialog(dlg)

--- a/dlgs_windows.go
+++ b/dlgs_windows.go
@@ -90,6 +90,12 @@ func utf16slice(ptr *uint16) []uint16 {
 
 func openfile(flags uint32, b *FileBuilder) (d filedlg) {
 	d.buf = make([]uint16, w32.MAX_PATH)
+	if b.StartFile != "" {
+		initialName, _ := syscall.UTF16FromString(b.StartFile)
+		for i := 0; i < len(initialName) && i < w32.MAX_PATH; i++ {
+			d.buf[i] = initialName[i]
+		}
+	}
 	d.opf = &w32.OPENFILENAME{
 		File:    utf16ptr(d.buf),
 		MaxFile: uint32(len(d.buf)),

--- a/dlgs_windows.go
+++ b/dlgs_windows.go
@@ -52,7 +52,7 @@ func (d filedlg) Filename() string {
 }
 
 func (b *FileBuilder) load() (string, error) {
-	d := openfile(w32.OFN_FILEMUSTEXIST, b)
+	d := openfile(w32.OFN_FILEMUSTEXIST|w32.OFN_NOCHANGEDIR, b)
 	if w32.GetOpenFileName(d.opf) {
 		return d.Filename(), nil
 	}
@@ -60,7 +60,7 @@ func (b *FileBuilder) load() (string, error) {
 }
 
 func (b *FileBuilder) save() (string, error) {
-	d := openfile(w32.OFN_OVERWRITEPROMPT, b)
+	d := openfile(w32.OFN_OVERWRITEPROMPT|w32.OFN_NOCHANGEDIR, b)
 	if w32.GetSaveFileName(d.opf) {
 		return d.Filename(), nil
 	}


### PR DESCRIPTION
Solves #26

I added the function `SetStartFile` to FileBuilder so that a predefined filename could be displayed on save dialogs. One use case for this is download managers. The user would not want to type out the file name since they are wanting to download a specific file, but instead they might want to rename part of it.