### PR TITLE
MacOS: deprecated warnings when starting the app with dialog package

### DIFF
--- a/cocoa/dlg.m
+++ b/cocoa/dlg.m
@@ -93,7 +93,8 @@ DlgResult fileDlg(FileDlgParams* params) {
 		[panel setTitle:[[NSString alloc] initWithUTF8String:self->params->title]];
 	}
 	if(self->params->numext > 0) {
-		[panel setAllowedFileTypes:[NSArray arrayWithObjects:(NSString**)self->params->exts count:self->params->numext]];
+		[panel setAllowedContentTypes:[NSArray arrayWithObjects:(NSString**)self->params->exts count:self->params->numext]];
+
 	}
 	if(self->params->relaxext) {
 		[panel setAllowsOtherFileTypes:YES];


### PR DESCRIPTION
setAllowedFileTypes is Deprecated
I only change the API to setAllowedContentTypes