### PR TITLE
linux: lazy call to XInitThreads

### DIFF
--- a/dlgs_linux.go
+++ b/dlgs_linux.go
@@ -12,16 +12,21 @@ package dialog
 // 	return gtk_file_chooser_dialog_new(title, parent, action, "Cancel", GTK_RESPONSE_CANCEL, acceptText, GTK_RESPONSE_ACCEPT, NULL);
 // }
 import "C"
-import "unsafe"
+import (
+	"sync"
+	"unsafe"
+)
 
-var initSuccess bool
-
-func init() {
-	C.XInitThreads()
-	initSuccess = (C.gtk_init_check(nil, nil) == C.TRUE)
-}
+var (
+	initSuccess bool
+	once        sync.Once
+)
 
 func checkStatus() {
+	once.Do(func() {
+		C.XInitThreads()
+		initSuccess = (C.gtk_init_check(nil, nil) == C.TRUE)
+	})
 	if !initSuccess {
 		panic("gtk initialisation failed; presumably no X server is available")
 	}


### PR DESCRIPTION
This prevents a program that can run as a command line tool from displaying "Unable to init server: Could not connect: Connection refused".