### PR TITLE
macOS: Activate NSApp and put the windows on top

### DIFF
--- a/cocoa/dlg.m
+++ b/cocoa/dlg.m
@@ -5,6 +5,16 @@ void* NSStr(void* buf, int len) {
 	return (void*)[[NSString alloc] initWithBytes:buf length:len encoding:NSUTF8StringEncoding];
 }
 
+void setActivationPolicy() {
+	NSApplicationActivationPolicy policy = [NSApp activationPolicy];
+	// prohibited NSApp will not show the panel at all.
+	// It probably means that this is not run in a GUI app, that would set the policy on its own,
+	// but in a terminal app - setting it to accessory will allow dialogs to show
+	if (policy == NSApplicationActivationPolicyProhibited) {
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+	}
+}
+
 void NSRelease(void* obj) {
 	[(NSObject*)obj release];
 }
@@ -52,10 +62,8 @@ DlgResult alertDlg(AlertDlgParams* params) {
 		[alert addButtonWithTitle:@"OK"];
 		break;
 	}
-	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-	[NSApp activateIgnoringOtherApps:YES];
-	[[alert window] makeKeyAndOrderFront:self];
-	[[alert window] setOrderedIndex:0];
+
+	setActivationPolicy();
 
 	self->result = [alert runModal] == NSAlertFirstButtonReturn ? DLG_OK : DLG_CANCEL;
 	return self->result;
@@ -110,8 +118,7 @@ DlgResult fileDlg(FileDlgParams* params) {
 		[panel setNameFieldStringValue:[[NSString alloc] initWithUTF8String:self->params->filename]];
 	}
 
-	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-	[NSApp activateIgnoringOtherApps:YES];
+	setActivationPolicy();
 
 	return [panel runModal];
 }

--- a/cocoa/dlg.m
+++ b/cocoa/dlg.m
@@ -52,6 +52,11 @@ DlgResult alertDlg(AlertDlgParams* params) {
 		[alert addButtonWithTitle:@"OK"];
 		break;
 	}
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+	[NSApp activateIgnoringOtherApps:YES];
+	[[alert window] makeKeyAndOrderFront:self];
+	[[alert window] setOrderedIndex:0];
+
 	self->result = [alert runModal] == NSAlertFirstButtonReturn ? DLG_OK : DLG_CANCEL;
 	return self->result;
 }
@@ -104,6 +109,10 @@ DlgResult fileDlg(FileDlgParams* params) {
 	if(self->params->filename != nil) {
 		[panel setNameFieldStringValue:[[NSString alloc] initWithUTF8String:self->params->filename]];
 	}
+
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+	[NSApp activateIgnoringOtherApps:YES];
+
 	return [panel runModal];
 }
 

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -7,10 +7,6 @@ import (
 )
 
 func main() {
-	/* Note that spawning a dialog from a non-graphical app like this doesn't
-	** quite work properly in OSX. The dialog appears fine, and mouse
-	** interaction works but keypresses go straight through the dialog.
-	** I'm guessing it has something to do with not having a main loop? */
 	dialog.Message("%s", "Please select a file").Title("Hello world!").Info()
 	file, err := dialog.File().Title("Save As").Filter("All Files", "*").Save()
 	fmt.Println(file)


### PR DESCRIPTION
Currently, macOS dialogs don't really work correctly, because the NSApp is not properly activated and, in case of dialogs, is not put on top.

This commit fixes that. Also, I deleted the comment in example, as it's no longer true with these changes.