### PR TITLE
Fix deprecated warnings for macOS

### DIFF
--- a/cocoa/dlg.m
+++ b/cocoa/dlg.m
@@ -1,4 +1,5 @@
 #import <Cocoa/Cocoa.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #include "dlg.h"
 
 void* NSStr(void* buf, int len) {
@@ -93,7 +94,15 @@ DlgResult fileDlg(FileDlgParams* params) {
 		[panel setTitle:[[NSString alloc] initWithUTF8String:self->params->title]];
 	}
 	if(self->params->numext > 0) {
-		[panel setAllowedFileTypes:[NSArray arrayWithObjects:(NSString**)self->params->exts count:self->params->numext]];
+		NSString** exts = (NSString**)self->params->exts;
+		NSMutableArray *types = [NSMutableArray array];
+
+		for (int i=0; i<self->params->numext; i++) {
+			NSString* ext = exts[i];
+			UTType *t = [UTType typeWithFilenameExtension: exts[i]];
+			[types addObject: t];
+		}
+		[panel setAllowedContentTypes:types];
 	}
 	if(self->params->relaxext) {
 		[panel setAllowsOtherFileTypes:YES];

--- a/cocoa/dlg_darwin.go
+++ b/cocoa/dlg_darwin.go
@@ -1,6 +1,6 @@
 package cocoa
 
-// #cgo darwin LDFLAGS: -framework Cocoa
+// #cgo darwin LDFLAGS: -framework Cocoa -framework UniformTypeIdentifiers
 // #include <stdlib.h>
 // #include <sys/syslimits.h>
 // #include "dlg.h"


### PR DESCRIPTION
macOS has a new framework UniformTypeIdentifiers that needs to be used for this.

Note that the behavior is not exactly the same - if you add "jpg", it will find a UTType that has "jpg" extension and will use that instead of creating a new type; so it will match both "jpg" and "jpeg".

I think it is acceptable (and, probably, even better).